### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,6 +1,6 @@
 function getBasePath() {
     const repoName = 'live-stream-summarizer';
-    if (location.hostname.includes('github.io')) {
+    if (location.hostname === 'github.io' || location.hostname.endsWith('.github.io')) {
         return `/${repoName}`;
     }
     return '';


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/live-stream-summarizer/security/code-scanning/3](https://github.com/aegisfleet/live-stream-summarizer/security/code-scanning/3)

The best way to fix this problem is to avoid substring matching and instead check for an exact match or a valid subdomain of `github.io`. In this context, we want to ensure that the hostname is either exactly `github.io` or ends with `.github.io` (which is how GitHub Pages custom domains are structured, e.g., `username.github.io`). This can be done by checking if `location.hostname` is exactly `github.io` or ends with `.github.io`. The change should be made in the `getBasePath` function in `src/js/main.js`, specifically on line 3. No new imports are needed, as this can be done with standard string methods.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
