### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Preview Site
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/aegisfleet/live-stream-summarizer/security/code-scanning/6](https://github.com/aegisfleet/live-stream-summarizer/security/code-scanning/6)

To fix the problem, add an explicit `permissions` block to the workflow or job. This block specifies what the workflow can do with the GITHUB_TOKEN (used by Actions). Since this workflow only checks out code and does not interact with issues, PRs, or modify repository contents, the minimal necessary permission is `contents: read`.  

The best way to implement this is to add a `permissions:` block after the workflow `name:` at the root (applies globally to all jobs, as there is only one). Ensure `permissions:` is at the same indentation as `name:` and `on:`. No code changes or imports are needed beyond this edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
